### PR TITLE
Refactor to remove enum

### DIFF
--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostIdResourceProviderTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostIdResourceProviderTest.java
@@ -65,7 +65,7 @@ class HostIdResourceProviderTest {
                     () -> {
                       HostIdResourceProvider provider =
                           new HostIdResourceProvider(
-                              () -> HostIdResourceProvider.OsType.LINUX, testCase.pathReader, null);
+                              () -> "linux", testCase.pathReader, null);
 
                       assertHostId(testCase.expectedValue, provider);
                     }))
@@ -90,7 +90,7 @@ class HostIdResourceProviderTest {
                     () -> {
                       HostIdResourceProvider provider =
                           new HostIdResourceProvider(
-                              () -> HostIdResourceProvider.OsType.WINDOWS,
+                              () -> "Windows 95",
                               null,
                               testCase.queryWindowsRegistry);
 


### PR DESCRIPTION
This is more or less all I was describing with the [comment](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10627#discussion_r1498066174) in 10627.

You can still use the supplier to make the tests easier I guess (I had hoped that you could just set the system property, but the dynamic test structure makes it hard to control precisely)...but the enum isn't required.