### PR TITLE
Test targeted CI path with jetty change

### DIFF
--- a/instrumentation/jetty/jetty-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/common/JettyHelper.java
+++ b/instrumentation/jetty/jetty-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/common/JettyHelper.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Trivial change to exercise targeted CI test path
 package io.opentelemetry.javaagent.instrumentation.jetty.common;
 
 import io.opentelemetry.context.Context;


### PR DESCRIPTION
## Summary
- Trivial jetty comment change to exercise the targeted CI test path
- Adds jdbc to smoke test suite mapping

## Purpose
Testing that the TARGETED CI path correctly identifies and runs only affected tests.