### PR TITLE
Keep declarative thread details distro-scoped

### DIFF
--- a/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/ConfigPropertiesBackedDeclarativeConfigProperties.java
+++ b/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/ConfigPropertiesBackedDeclarativeConfigProperties.java
@@ -225,15 +225,15 @@ public final class ConfigPropertiesBackedDeclarativeConfigProperties
       translatedPath.append(translateName(segments[i]));
     }
 
-    // java.agent.* maps to otel.javaagent.* (not otel.instrumentation.agent.*)
-    if (segments.length > 0 && segments[0].equals("agent")) {
-      if (translatedPath.length() == "agent".length()) {
-        return "otel.javaagent";
-      }
-      return "otel.javaagent." + translatedPath.substring("agent.".length());
+    String translated = translatedPath.toString();
+    if (translated.equals("agent")) {
+      return "otel.javaagent";
+    }
+    if (translated.startsWith("agent.")) {
+      return "otel.javaagent." + translated.substring("agent.".length());
     }
 
-    return "otel.instrumentation." + translatedPath;
+    return "otel.instrumentation." + translated;
   }
 
   private String pathWithName(String name) {

--- a/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME;
 import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 
 import io.opentelemetry.api.trace.SpanKind;
 import org.assertj.core.api.AbstractCharSequenceAssert;
@@ -72,7 +74,10 @@ class OtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest {
                                         satisfies(
                                             SERVICE_INSTANCE_ID,
                                             AbstractCharSequenceAssert::isNotBlank)))
-                        .hasAttribute(HTTP_ROUTE, "/ping"),
+                        .hasAttribute(HTTP_ROUTE, "/ping")
+                        .hasAttributesSatisfying(
+                            satisfies(THREAD_ID, val -> val.isNotZero()),
+                            satisfies(THREAD_NAME, val -> val.isNotBlank())),
                 AbstractSpringStarterSmokeTest::withSpanAssert));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml
+++ b/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml
@@ -38,6 +38,10 @@ otel:
       - tracecontext:
       - baggage:
 
+  distribution:
+    spring_starter:
+      thread_details_enabled: true
+
   instrumentation/development:
     java:
       common:


### PR DESCRIPTION
This is a narrower alternative to @trask 's #13.

What it keeps:
- declarative thread-details stays distro-scoped for the spring starter via `otel.distribution.spring_starter.thread_details_enabled`
- no `ConfigProvider` rewrite, since the distro node is not exposed through `getInstrumentationConfig()` today

What it salvages from the PR:
- declarative-config smoke coverage now enables the distro-scoped key from `application.yaml` and asserts `thread.id` / `thread.name` on the server span
- the unrelated `java.agent` translation cleanup in `ConfigPropertiesBackedDeclarativeConfigProperties`, using the safer `translated.equals("agent")` / `startsWith("agent.")` form

This keeps the existing design from #15209 while preserving the useful verification and robustness pieces from #13.
